### PR TITLE
Fix Label style

### DIFF
--- a/src/components/ui/Label.tsx
+++ b/src/components/ui/Label.tsx
@@ -3,7 +3,8 @@ import styled from 'styled-components';
 const Label = styled.div`
   display: flex;
   align-items: center;
-  width: 95%;
+  flex-grow: 1;
+  width: 1%;
   padding-left: 2%;
   padding-right: 2%;
 `;


### PR DESCRIPTION
labelの値が a * 100 みたいに長いときに右のボタン（アイコン）が左に切れてしまっていたので修正しました。
普通の文字列を入れたときはword-breakが仕事をして改行してくれるので問題ないです

Before
![スクリーンショット 2019-11-18 23 57 26](https://user-images.githubusercontent.com/19319792/69063113-44c2a800-0a5f-11ea-9f39-c925cbe901b6.png)

After
![スクリーンショット 2019-11-18 23 57 51](https://user-images.githubusercontent.com/19319792/69063139-4f7d3d00-0a5f-11ea-9519-db55e05a5c14.png)

